### PR TITLE
fix cocoapods-foundation-headers always-on issue

### DIFF
--- a/lib/cocoapods_plugin.rb
+++ b/lib/cocoapods_plugin.rb
@@ -1,1 +1,3 @@
-require 'cocoapods-foundation-headers/foundation_headers'
+Pod::HooksManager.register('cocoapods-foundation-headers', :pre_install) do |context, options|
+    require 'cocoapods-foundation-headers/foundation_headers'
+end


### PR DESCRIPTION
when cocoapods-foundation-headers is installed, it is always on.  whether or not set `plugin "cocoapods-foundation-headers"`.